### PR TITLE
Update action config to Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,5 +37,5 @@ inputs:
     required: false
     default: 'true'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist_gh_action/index.js'


### PR DESCRIPTION
🚨 Node 12 has an end of life on April 30, 2022.

The GitHub Actions workflow gives the following deprecation warning while running the action:

> Node.js 12 actions are deprecated. For more information see: github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12.

This PR updates the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/) rather then node12. (#35)

This is supported on all Actions Runners v2.285.0 or later.

Signed-off-by: Enes <ahmedenesturan@gmail.com>